### PR TITLE
Deprecate `phase.active` in favor of `policy.activePhase`

### DIFF
--- a/packages/state-plans/data/policies/alabama/vaccination.json
+++ b/packages/state-plans/data/policies/alabama/vaccination.json
@@ -10,10 +10,10 @@
 			"url": "tel:1-855-566-5333"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/alaska/vaccination.json
+++ b/packages/state-plans/data/policies/alaska/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "http://dhss.alaska.gov/dph/Epi/id/Pages/COVID-19/VaccineInfo.aspx"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -15,7 +16,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/american_samoa/vaccination.json
+++ b/packages/state-plans/data/policies/american_samoa/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.americansamoa.gov/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/arizona/regions/apache/vaccination.json
+++ b/packages/state-plans/data/policies/arizona/regions/apache/vaccination.json
@@ -1,3 +1,3 @@
 {
-	"activePhase": "arizona.1b"
+	"activePhase": "1b"
 }

--- a/packages/state-plans/data/policies/arizona/regions/la_paz/vaccination.json
+++ b/packages/state-plans/data/policies/arizona/regions/la_paz/vaccination.json
@@ -1,3 +1,3 @@
 {
-	"activePhase": "arizona.1b"
+	"activePhase": "1b"
 }

--- a/packages/state-plans/data/policies/arizona/regions/navajo/vaccination.json
+++ b/packages/state-plans/data/policies/arizona/regions/navajo/vaccination.json
@@ -1,3 +1,3 @@
 {
-	"activePhase": "arizona.1b"
+	"activePhase": "1b"
 }

--- a/packages/state-plans/data/policies/arizona/regions/santa_cruz/vaccination.json
+++ b/packages/state-plans/data/policies/arizona/regions/santa_cruz/vaccination.json
@@ -1,3 +1,3 @@
 {
-	"activePhase": "arizona.1b"
+	"activePhase": "1b"
 }

--- a/packages/state-plans/data/policies/arizona/vaccination.json
+++ b/packages/state-plans/data/policies/arizona/vaccination.json
@@ -5,7 +5,7 @@
 			"url": "https://azdhs.gov/preparedness/epidemiology-disease-control/infectious-disease-epidemiology/index.php#novel-coronavirus-vaccine"
 		}
 	},
-	"activePhase": "arizona.1b_prioritized",
+	"activePhase": "1b_prioritized",
 	"phases": [
 		{
 			"id": "1a",
@@ -18,7 +18,7 @@
 		{
 			"id": "1b_prioritized",
 			"label": "Prioritized Phase 1B",
-			"extends": "arizona.1a",
+			"extends": "1a",
 			"qualifications": [
 				"c19.eligibility.question/education_childcare_worker.AZ",
 				"c19.eligibility.question/proctective_services_worker.AZ",

--- a/packages/state-plans/data/policies/arkansas/vaccination.json
+++ b/packages/state-plans/data/policies/arkansas/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.healthy.arkansas.gov/programs-services/topics/covid-19-vaccination-plan"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/california/vaccination.json
+++ b/packages/state-plans/data/policies/california/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID-19Vaccine.aspx"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/colorado/vaccination.json
+++ b/packages/state-plans/data/policies/colorado/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://covid19.colorado.gov/vaccine"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -14,8 +15,7 @@
 			]
 		},
 		{
-			"id": "1b",
-			"active": true,
+			"id": "1b",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/connecticut/vaccination.json
+++ b/packages/state-plans/data/policies/connecticut/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://portal.ct.gov/Coronavirus/covid-19%20vaccinations"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/delaware/vaccination.json
+++ b/packages/state-plans/data/policies/delaware/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://coronavirus.delaware.gov/vaccine/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/district_of_columbia/vaccination.json
+++ b/packages/state-plans/data/policies/district_of_columbia/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://coronavirus.dc.gov/vaccine"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -16,7 +17,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/federated_states_of_micronesia/vaccination.json
+++ b/packages/state-plans/data/policies/federated_states_of_micronesia/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.fsmgov.org/index.html"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/florida/vaccination.json
+++ b/packages/state-plans/data/policies/florida/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://floridahealthcovid19.gov/covid-19-vaccines-in-florida/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/georgia/vaccination.json
+++ b/packages/state-plans/data/policies/georgia/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://dph.georgia.gov/covid-vaccine"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/guam/vaccination.json
+++ b/packages/state-plans/data/policies/guam/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://dphss.guam.gov/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/hawaii/vaccination.json
+++ b/packages/state-plans/data/policies/hawaii/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://hawaiicovid19.com/vaccine/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/idaho/vaccination.json
+++ b/packages/state-plans/data/policies/idaho/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://coronavirus.idaho.gov/covid-19-vaccine/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/illinois/vaccination.json
+++ b/packages/state-plans/data/policies/illinois/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.dph.illinois.gov/covid19/vaccine-faq"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/indiana/vaccination.json
+++ b/packages/state-plans/data/policies/indiana/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://www.coronavirus.in.gov/vaccine/index.htm"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -16,7 +17,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/iowa/vaccination.json
+++ b/packages/state-plans/data/policies/iowa/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://idph.iowa.gov/Emerging-Health-Issues/Novel-Coronavirus/Vaccine"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/kansas/vaccination.json
+++ b/packages/state-plans/data/policies/kansas/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.kansasvaccine.gov/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/kentucky/vaccination.json
+++ b/packages/state-plans/data/policies/kentucky/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://govstatus.egov.com/ky-covid-vaccine"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/louisiana/vaccination.json
+++ b/packages/state-plans/data/policies/louisiana/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://ldh.la.gov/index.cfm/page/4042"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -15,7 +16,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/maine/vaccination.json
+++ b/packages/state-plans/data/policies/maine/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.maine.gov/covid19/vaccines"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/marshall_islands/vaccination.json
+++ b/packages/state-plans/data/policies/marshall_islands/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "http://rmihealth.org/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/maryland/vaccination.json
+++ b/packages/state-plans/data/policies/maryland/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://covidlink.maryland.gov/content/vaccine/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/massachusets/vaccination.json
+++ b/packages/state-plans/data/policies/massachusets/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.mass.gov/info-details/massachusetts-covid-19-vaccine-information"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/michigan/vaccination.json
+++ b/packages/state-plans/data/policies/michigan/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://www.michigan.gov/coronavirus/0,9753,7-406-98178_103214---,00.html"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -15,7 +16,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/minnesota/vaccination.json
+++ b/packages/state-plans/data/policies/minnesota/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.health.state.mn.us/diseases/coronavirus/vaccine.html"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/mississippi/vaccination.json
+++ b/packages/state-plans/data/policies/mississippi/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://msdh.ms.gov/msdhsite/_static/14,0,420,976.html"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -15,7 +16,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/missouri/vaccination.json
+++ b/packages/state-plans/data/policies/missouri/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://covidvaccine.mo.gov/residents/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/montana/vaccination.json
+++ b/packages/state-plans/data/policies/montana/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://dphhs.mt.gov/publichealth/cdepi/diseases/coronavirusvaccine/loginstate.aspx"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/nebraska/vaccination.json
+++ b/packages/state-plans/data/policies/nebraska/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "http://dhhs.ne.gov/Pages/COVID-19-Vaccine-Information.aspx"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/nevada/vaccination.json
+++ b/packages/state-plans/data/policies/nevada/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.immunizenevada.org/nv-covid-fighter"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/new_hampshire/vaccination.json
+++ b/packages/state-plans/data/policies/new_hampshire/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.nh.gov/covid19/resources-guidance/vaccination-planning.htm"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/new_jersey/vaccination.json
+++ b/packages/state-plans/data/policies/new_jersey/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://www.nj.gov/health/cd/topics/covid2019_vaccination.shtml"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -15,7 +16,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/new_mexico/vaccination.json
+++ b/packages/state-plans/data/policies/new_mexico/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://cv.nmhealth.org/covid-vaccine/"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -15,7 +16,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/new_york/vaccination.json
+++ b/packages/state-plans/data/policies/new_york/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://covid19vaccine.health.ny.gov/"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -15,7 +16,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/north_carolina/vaccination.json
+++ b/packages/state-plans/data/policies/north_carolina/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://covid19.ncdhhs.gov/vaccines"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/north_dakota/vaccination.json
+++ b/packages/state-plans/data/policies/north_dakota/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.health.nd.gov/immunization-guidance-public"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/nothern_mariana_islands/vaccination.json
+++ b/packages/state-plans/data/policies/nothern_mariana_islands/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.vaccinatecnmi.com/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/ohio/vaccination.json
+++ b/packages/state-plans/data/policies/ohio/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://coronavirus.ohio.gov/wps/portal/gov/covid-19/covid-19-vaccination-program"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/oklahoma/vaccination.json
+++ b/packages/state-plans/data/policies/oklahoma/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://oklahoma.gov/covid19/vaccine-information.html"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/oregon/vaccination.json
+++ b/packages/state-plans/data/policies/oregon/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://covidvaccine.oregon.gov/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/palau/vaccination.json
+++ b/packages/state-plans/data/policies/palau/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "http://www.palauhealth.org/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/pennsylvania/vaccination.json
+++ b/packages/state-plans/data/policies/pennsylvania/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.health.pa.gov/topics/disease/coronavirus/Pages/Vaccine.aspx"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/puerto_rico/vaccination.json
+++ b/packages/state-plans/data/policies/puerto_rico/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "http://www.salud.gov.pr/Pages/coronavirus.aspx"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/rhode_island/vaccination.json
+++ b/packages/state-plans/data/policies/rhode_island/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://covid.ri.gov/vaccination"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/south_carolina/vaccination.json
+++ b/packages/state-plans/data/policies/south_carolina/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://scdhec.gov/covid19/covid-19-vaccine"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/south_dakota/vaccination.json
+++ b/packages/state-plans/data/policies/south_dakota/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://doh.sd.gov/COVID/Vaccine/default.aspx"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/tennessee/vaccination.json
+++ b/packages/state-plans/data/policies/tennessee/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://www.tn.gov/health/cedep/ncov/covid-19-vaccine-information.html"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -17,7 +18,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/texas/vaccination.json
+++ b/packages/state-plans/data/policies/texas/vaccination.json
@@ -5,6 +5,7 @@
 			"url": "https://www.dshs.state.tx.us/coronavirus/immunize/vaccine.aspx"
 		}
 	},
+	"activePhase": "1b",
 	"phases": [
 		{
 			"id": "1a",
@@ -15,7 +16,6 @@
 		},
 		{
 			"id": "1b",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/us_virgin_islands/vaccination.json
+++ b/packages/state-plans/data/policies/us_virgin_islands/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.covid19usvi.com/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/utah/vaccination.json
+++ b/packages/state-plans/data/policies/utah/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://coronavirus.utah.gov/vaccine/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/vermont/vaccination.json
+++ b/packages/state-plans/data/policies/vermont/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.healthvermont.gov/covid-19/vaccine"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
 			"id": "1a",
-			"active": true,
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/virginia/vaccination.json
+++ b/packages/state-plans/data/policies/virginia/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.vdh.virginia.gov/covid-19-vaccine/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/washington/vaccination.json
+++ b/packages/state-plans/data/policies/washington/vaccination.json
@@ -8,10 +8,10 @@
 			"url": "https://www.doh.wa.gov/Emergencies/COVID19/vaccine"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/west_virginia/vaccination.json
+++ b/packages/state-plans/data/policies/west_virginia/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://dhhr.wv.gov/COVID-19/Pages/Vaccine.aspx"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/data/policies/wisconsin/vaccination.json
+++ b/packages/state-plans/data/policies/wisconsin/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://www.dhs.wisconsin.gov/covid-19/vaccine.htm"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident"

--- a/packages/state-plans/data/policies/wyoming/vaccination.json
+++ b/packages/state-plans/data/policies/wyoming/vaccination.json
@@ -5,10 +5,10 @@
 			"url": "https://health.wyo.gov/publichealth/immunization/wyoming-covid-19-vaccine-information/"
 		}
 	},
+	"activePhase": "1a",
 	"phases": [
 		{
-			"id": "1a",
-			"active": true,
+			"id": "1a",			
 			"qualifications": [
 				"c19.eligibility.question/healthcare_worker",
 				"c19.eligibility.question/long_term_care_resident",

--- a/packages/state-plans/scripts/schema/schema.ts
+++ b/packages/state-plans/scripts/schema/schema.ts
@@ -75,11 +75,6 @@ export const VaccinationPhase = {
 				'An optional label to present when displaying information about the phase. The system will be "Phase " + phase.id.toUpperCase()',
 			type: 'string',
 		},
-		active: {
-			description:
-				'A flag indicating that this phase is currently active for the region. Only one phase in the phase array should be marked as active.',
-			type: 'boolean',
-		},
 		qualifications: {
 			type: 'array',
 			items: {


### PR DESCRIPTION
This lets us decouple policy definition from acting policies, which resolves some schema issues with nested regions.