### PR TITLE
Schema Update: Use Objects for Question Model

### DIFF
--- a/packages/plans/data/policies/alabama/vaccination.json
+++ b/packages/plans/data/policies/alabama/vaccination.json
@@ -15,29 +15,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/alaska/vaccination.json
+++ b/packages/plans/data/policies/alaska/vaccination.json
@@ -10,31 +10,61 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.55_up",
-				"c19.eligibility.question/health.1b.AK",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.55_up"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.AK"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.55_up",
-				"c19.eligibility.question/congregate",
-				"c19.eligibility.question/unserved.1c.AK"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.55_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				},
+				{
+					"question": "c19.eligibility.question/unserved.1c.AK"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/american_samoa/vaccination.json
+++ b/packages/plans/data/policies/american_samoa/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/arizona/vaccination.json
+++ b/packages/plans/data/policies/arizona/vaccination.json
@@ -10,38 +10,70 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker.AZ",
-				"c19.eligibility.question/long_term_care_resident.AZ",
-				"c19.eligibility.question/ems_worker.AZ"
+				{
+					"question": "c19.eligibility.question/healthcare_worker.AZ"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident.AZ"
+				},
+				{
+					"question": "c19.eligibility.question/ems_worker.AZ"
+				}
 			]
 		},
 		{
 			"id": "1b_prioritized",
 			"label": "Prioritized Phase 1B",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker.AZ",
-				"c19.eligibility.question/long_term_care_resident.AZ",
-				"c19.eligibility.question/ems_worker.AZ",
-				"c19.eligibility.question/education_childcare_worker.AZ",
-				"c19.eligibility.question/proctective_services_worker.AZ",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker.AZ"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident.AZ"
+				},
+				{
+					"question": "c19.eligibility.question/ems_worker.AZ"
+				},
+				{
+					"question": "c19.eligibility.question/education_childcare_worker.AZ"
+				},
+				{
+					"question": "c19.eligibility.question/proctective_services_worker.AZ"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.AZ"
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.AZ"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.AZ",
-				"c19.eligibility.question/health"
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.AZ"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/arkansas/vaccination.json
+++ b/packages/plans/data/policies/arkansas/vaccination.json
@@ -10,29 +10,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.firefighter_leo"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.firefighter_leo"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.firefighter_leo",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.70_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.firefighter_leo"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.70_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/california/vaccination.json
+++ b/packages/plans/data/policies/california/vaccination.json
@@ -10,29 +10,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.CA",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.CA"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.CA"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.CA"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.CA"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.CA"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/colorado/vaccination.json
+++ b/packages/plans/data/policies/colorado/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.CO",
-				"c19.eligibility.question/age.70_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.CO"
+				},
+				{
+					"question": "c19.eligibility.question/age.70_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/connecticut/vaccination.json
+++ b/packages/plans/data/policies/connecticut/vaccination.json
@@ -10,29 +10,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/delaware/vaccination.json
+++ b/packages/plans/data/policies/delaware/vaccination.json
@@ -10,28 +10,52 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/district_of_columbia/vaccination.json
+++ b/packages/plans/data/policies/district_of_columbia/vaccination.json
@@ -10,32 +10,64 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/health.1a.DC.inpatient_psychiatric"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.DC.inpatient_psychiatric"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/health.1a.DC.inpatient_psychiatric",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.DC"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.DC.inpatient_psychiatric"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.DC"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/health.1a.DC.inpatient_psychiatric",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/congregate.DC"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.DC.inpatient_psychiatric"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.DC"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/federated_states_of_micronesia/vaccination.json
+++ b/packages/plans/data/policies/federated_states_of_micronesia/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/florida/vaccination.json
+++ b/packages/plans/data/policies/florida/vaccination.json
@@ -10,30 +10,58 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/health.1a.FL.extremely_vulnerable",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.FL.extremely_vulnerable"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/health.1a.FL.extremely_vulnerable",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.FL.extremely_vulnerable"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/georgia/vaccination.json
+++ b/packages/plans/data/policies/georgia/vaccination.json
@@ -10,32 +10,64 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/essential_worker.firefighter_leo",
-				"c19.eligibility.question/essential_worker.1a.GA.caregiver_of_65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.firefighter_leo"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.GA.caregiver_of_65_up"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/essential_worker.firefighter_leo",
-				"c19.eligibility.question/essential_worker.1a.GA.caregiver_of_65_up",
-				"c19.eligibility.question/essential_worker"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.firefighter_leo"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.GA.caregiver_of_65_up"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/guam/vaccination.json
+++ b/packages/plans/data/policies/guam/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/hawaii/vaccination.json
+++ b/packages/plans/data/policies/hawaii/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/idaho/vaccination.json
+++ b/packages/plans/data/policies/idaho/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/illinois/vaccination.json
+++ b/packages/plans/data/policies/illinois/vaccination.json
@@ -10,29 +10,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.IL"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.IL"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.IL"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.IL"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/indiana/vaccination.json
+++ b/packages/plans/data/policies/indiana/vaccination.json
@@ -10,29 +10,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.ff_leo_corrections"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.ff_leo_corrections"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.ff_leo_corrections",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.60_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.ff_leo_corrections"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.60_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.60_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.60_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/iowa/vaccination.json
+++ b/packages/plans/data/policies/iowa/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/kansas/vaccination.json
+++ b/packages/plans/data/policies/kansas/vaccination.json
@@ -10,29 +10,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.KS",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.KS"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/kentucky/vaccination.json
+++ b/packages/plans/data/policies/kentucky/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.KY",
-				"c19.eligibility.question/age.70_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.KY"
+				},
+				{
+					"question": "c19.eligibility.question/age.70_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/louisiana/vaccination.json
+++ b/packages/plans/data/policies/louisiana/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker.in_hospital",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker.in_hospital"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.LA",
-				"c19.eligibility.question/age.70_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.LA"
+				},
+				{
+					"question": "c19.eligibility.question/age.70_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/maine/vaccination.json
+++ b/packages/plans/data/policies/maine/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/marshall_islands/vaccination.json
+++ b/packages/plans/data/policies/marshall_islands/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/maryland/vaccination.json
+++ b/packages/plans/data/policies/maryland/vaccination.json
@@ -10,35 +10,73 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo_corrections",
-				"c19.eligibility.question/essential_worker.1a.MD.judiciary_or_nursing_home_staff"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo_corrections"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.MD.judiciary_or_nursing_home_staff"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo_corrections",
-				"c19.eligibility.question/essential_worker.1a.MD.judiciary_or_nursing_home_staff",
-				"c19.eligibility.question/essential_worker.1b.MD",
-				"c19.eligibility.question/age.75_up",
-				"c19.eligibility.question/congregate.MD"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo_corrections"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.MD.judiciary_or_nursing_home_staff"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.MD"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.MD"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo_corrections",
-				"c19.eligibility.question/essential_worker.1a.MD.judiciary_or_nursing_home_staff",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.MD"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo_corrections"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.MD.judiciary_or_nursing_home_staff"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.MD"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/massachusets/massachusets.csv
+++ b/packages/plans/data/policies/massachusets/massachusets.csv
@@ -1,2 +1,3 @@
 String ID,en-us,ko-kr,vi-vn,zh-cn,es-us,de-de,es-es,fi-fi,fr-fr,he-il,it-it,ja-jp,pt-pt,sv-se,th-th
 c19.eligibility.question/health.1b.MA,Are you age 16+ with at least 2 high-risk medical conditions?,,,,,,,,,,,,,,
+c19.links/workflow.MA,"Massachusetts PhaseFinder",,,,,,,,,,,,,,

--- a/packages/plans/data/policies/massachusets/vaccination.json
+++ b/packages/plans/data/policies/massachusets/vaccination.json
@@ -3,35 +3,63 @@
 		"info": {
 			"text": "CDC/Massachusetts/state_link",
 			"url": "https://www.mass.gov/info-details/massachusetts-covid-19-vaccine-information"
+		},
+		"workflow": {
+			"text": "c19.links/workflow.MA",
+			"url": "https://www.mass.gov/covid-19-vaccine"
 		}
 	},
-	"activePhase": "1a",
+	"activePhase": "2.group1",
 	"phases": [
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/age.75_up",
-				"c19.eligibility.question/health.1b.MA"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.MA"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/michigan/vaccination.json
+++ b/packages/plans/data/policies/michigan/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/minnesota/vaccination.json
+++ b/packages/plans/data/policies/minnesota/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/mississippi/vaccination.json
+++ b/packages/plans/data/policies/mississippi/vaccination.json
@@ -10,28 +10,52 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.MS"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.MS"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/missouri/vaccination.json
+++ b/packages/plans/data/policies/missouri/vaccination.json
@@ -10,28 +10,52 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/montana/vaccination.json
+++ b/packages/plans/data/policies/montana/vaccination.json
@@ -10,32 +10,64 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.70_up",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/american_indian_poc.MT",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.70_up"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/american_indian_poc.MT"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/american_indian_poc.MT",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/american_indian_poc.MT"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/nebraska/vaccination.json
+++ b/packages/plans/data/policies/nebraska/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/nevada/vaccination.json
+++ b/packages/plans/data/policies/nevada/vaccination.json
@@ -10,31 +10,61 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo_corrections",
-				"c19.eligibility.question/essential_worker.1a.NV.safety_natsec"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo_corrections"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.NV.safety_natsec"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo_corrections",
-				"c19.eligibility.question/essential_worker.1a.NV.safety_natsec",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo_corrections"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.NV.safety_natsec"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/new_hampshire/vaccination.json
+++ b/packages/plans/data/policies/new_hampshire/vaccination.json
@@ -10,33 +10,67 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.firefighter_leo"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.firefighter_leo"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.firefighter_leo",
-				"c19.eligibility.question/essential_worker.1b.NH",
-				"c19.eligibility.question/age.75_up",
-				"c19.eligibility.question/health.1b.NH",
-				"c19.eligibility.question/congregate.NH"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.firefighter_leo"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.NH"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.NH"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.NH"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/health.1b.NH",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/congregate.NH"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.NH"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.NH"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/new_jersey/vaccination.json
+++ b/packages/plans/data/policies/new_jersey/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.firefighter_leo",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.firefighter_leo"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/new_mexico/vaccination.json
+++ b/packages/plans/data/policies/new_mexico/vaccination.json
@@ -10,30 +10,58 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.NM",
-				"c19.eligibility.question/age.75_up",
-				"c19.eligibility.question/health.1b.NM",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.NM"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.NM"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/new_york/vaccination.json
+++ b/packages/plans/data/policies/new_york/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.NY",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.NY"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/north_carolina/vaccination.json
+++ b/packages/plans/data/policies/north_carolina/vaccination.json
@@ -10,28 +10,52 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/north_dakota/vaccination.json
+++ b/packages/plans/data/policies/north_dakota/vaccination.json
@@ -10,30 +10,58 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.ND",
-				"c19.eligibility.question/health.1b.ND",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.ND"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.ND"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/nothern_mariana_islands/vaccination.json
+++ b/packages/plans/data/policies/nothern_mariana_islands/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/ohio/vaccination.json
+++ b/packages/plans/data/policies/ohio/vaccination.json
@@ -10,30 +10,58 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/health.1a.OH.psychiatric"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.OH.psychiatric"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/health.1a.OH.psychiatric",
-				"c19.eligibility.question/health.1b.OH",
-				"c19.eligibility.question/essential_worker.k12",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.OH.psychiatric"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.OH"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.k12"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/oklahoma/vaccination.json
+++ b/packages/plans/data/policies/oklahoma/vaccination.json
@@ -10,30 +10,58 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/congregate.OK"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.OK"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/congregate.OK"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.OK"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/oregon/vaccination.json
+++ b/packages/plans/data/policies/oregon/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/palau/vaccination.json
+++ b/packages/plans/data/policies/palau/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/pennsylvania/vaccination.json
+++ b/packages/plans/data/policies/pennsylvania/vaccination.json
@@ -10,31 +10,61 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b.PA",
-				"c19.eligibility.question/age.75_up",
-				"c19.eligibility.question/health.1b.PA",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.PA"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.PA"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/health.1b.PA",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.PA"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/puerto_rico/vaccination.json
+++ b/packages/plans/data/policies/puerto_rico/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/rhode_island/vaccination.json
+++ b/packages/plans/data/policies/rhode_island/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/south_carolina/vaccination.json
+++ b/packages/plans/data/policies/south_carolina/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/south_dakota/vaccination.json
+++ b/packages/plans/data/policies/south_dakota/vaccination.json
@@ -10,32 +10,64 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo_corrections"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo_corrections"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo_corrections",
-				"c19.eligibility.question/essential_worker.1b.SD",
-				"c19.eligibility.question/health.1b.SD",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo_corrections"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.SD"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.SD"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/tennessee/vaccination.json
+++ b/packages/plans/data/policies/tennessee/vaccination.json
@@ -10,30 +10,58 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/health.1a.TN.non_independent",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.TN.non_independent"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/health.1a.TN.non_independent",
-				"c19.eligibility.question/essential_worker.1b.TN"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/health.1a.TN.non_independent"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b.TN"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/texas/vaccination.json
+++ b/packages/plans/data/policies/texas/vaccination.json
@@ -10,28 +10,52 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/health"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/us_virgin_islands/vaccination.json
+++ b/packages/plans/data/policies/us_virgin_islands/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/utah/vaccination.json
+++ b/packages/plans/data/policies/utah/vaccination.json
@@ -10,31 +10,61 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.k12",
-				"c19.eligibility.question/essential_worker.1a.UT.first_responder"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.k12"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.UT.first_responder"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.k12",
-				"c19.eligibility.question/essential_worker.1a.UT.first_responder",
-				"c19.eligibility.question/age.70_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.k12"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1a.UT.first_responder"
+				},
+				{
+					"question": "c19.eligibility.question/age.70_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/vermont/vaccination.json
+++ b/packages/plans/data/policies/vermont/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/virginia/vaccination.json
+++ b/packages/plans/data/policies/virginia/vaccination.json
@@ -10,29 +10,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up",
-				"c19.eligibility.question/congregate.VA"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.VA"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate.VA"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate.VA"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/washington/vaccination.json
+++ b/packages/plans/data/policies/washington/vaccination.json
@@ -14,36 +14,76 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.70_up",
-				"c19.eligibility.question/congregate",
-				"c19.eligibility.question/congregate_services.WA",
-				"c19.eligibility.question/congregate_worker.WA",
-				"c19.eligibility.question/multigen.WA",
-				"c19.eligibility.question/health.1b.WA"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.70_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				},
+				{
+					"question": "c19.eligibility.question/congregate_services.WA"
+				},
+				{
+					"question": "c19.eligibility.question/congregate_worker.WA"
+				},
+				{
+					"question": "c19.eligibility.question/multigen.WA"
+				},
+				{
+					"question": "c19.eligibility.question/health.1b.WA"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up",
-				"c19.eligibility.question/congregate",
-				"c19.eligibility.question/congregate_services.WA",
-				"c19.eligibility.question/congregate_worker.WA",
-				"c19.eligibility.question/multigen.WA"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				},
+				{
+					"question": "c19.eligibility.question/congregate"
+				},
+				{
+					"question": "c19.eligibility.question/congregate_services.WA"
+				},
+				{
+					"question": "c19.eligibility.question/congregate_worker.WA"
+				},
+				{
+					"question": "c19.eligibility.question/multigen.WA"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/west_virginia/vaccination.json
+++ b/packages/plans/data/policies/west_virginia/vaccination.json
@@ -10,28 +10,52 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/age.80_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/age.80_up"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/wisconsin/vaccination.json
+++ b/packages/plans/data/policies/wisconsin/vaccination.json
@@ -10,27 +10,49 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.75_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.75_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/data/policies/wyoming/vaccination.json
+++ b/packages/plans/data/policies/wyoming/vaccination.json
@@ -10,29 +10,55 @@
 		{
 			"id": "1a",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo"
+				}
 			]
 		},
 		{
 			"id": "1b",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker.leo",
-				"c19.eligibility.question/essential_worker.1b",
-				"c19.eligibility.question/age.70_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.leo"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker.1b"
+				},
+				{
+					"question": "c19.eligibility.question/age.70_up"
+				}
 			]
 		},
 		{
 			"id": "1c",
 			"qualifications": [
-				"c19.eligibility.question/healthcare_worker",
-				"c19.eligibility.question/long_term_care_resident",
-				"c19.eligibility.question/essential_worker",
-				"c19.eligibility.question/health",
-				"c19.eligibility.question/age.65_up"
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.65_up"
+				}
 			]
 		}
 	]

--- a/packages/plans/scripts/validatePolicies/index.ts
+++ b/packages/plans/scripts/validatePolicies/index.ts
@@ -139,7 +139,12 @@ function checkStringIds(
 	}
 	if (vaccinationPlan.phases) {
 		vaccinationPlan.phases.forEach((phase: RolloutPhase) => {
-			phase.qualifications.forEach((qual: Qualification) => checkString(qual))
+			phase.qualifications.forEach((qual: Qualification) => {
+				checkString(qual.question)
+				if (qual.moreInfo) {
+					checkString(qual.moreInfo)
+				}
+			})
 		})
 	}
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -72,4 +72,14 @@ export interface RolloutPhase {
 	qualifications: Qualification[]
 }
 
-export type Qualification = string
+export interface Qualification {
+	/**
+	 * The ID of the qualification question to ask
+	 */
+	question: string
+
+	/**
+	 * The ID of the clarifying text to provide (e.g. what defines an essential worker)
+	 */
+	moreInfo?: string
+}


### PR DESCRIPTION
Instead of using strings, Qualification is now an object.
This object has two properties to start with:

`question`: The ID of the question to ask in the lookup table (what was previously in the model)
`moreInfo`: The ID of a more-info blurb to provide when they ask for more details on the question. (e.g. what is an essential worker?)