### PR TITLE
Use task names that contain a ":" character at the top level

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         run: yarn ci
 
       - name: Deploy to Dev
-        run: yarn deploy_all
+        run: yarn deploy:all
         if: github.ref == 'refs/heads/main'
         env:
           HEALTHBOT_HOST: ${{ secrets.HEALTHBOT_HOST }}
@@ -50,7 +50,7 @@ jobs:
           HEALTHBOT_API_SECRET: ${{ secrets.HEALTHBOT_API_KEY_DEV }}
 
       - name: Deploy to Integ
-        run: yarn deploy_all
+        run: yarn deploy:all
         if: github.ref == 'refs/heads/main'
         env:
           HEALTHBOT_HOST: ${{ secrets.HEALTHBOT_HOST }}

--- a/package.json
+++ b/package.json
@@ -3,18 +3,17 @@
 	"description": "Microsoft COVID-19 Eligibility Bot",
 	"scripts": {
 		"preinstall": "npx only-allow yarn",
-		"clean_all": "yarn workspaces foreach -pv run clean",
-		"build_all": "yarn workspaces foreach -pvt run build",
-		"test_all": "yarn workspaces foreach -pvt run test",
-		"start_all": "yarn workspaces foreach -piv run start",
-		"deploy_all": "yarn workspaces foreach -piv run deploy",
-		"unit_test": "jest --ci --coverage",
+		"clean:all": "yarn workspaces foreach -pv run clean",
+		"build:": "yarn workspaces foreach -pvt run build",
+		"test:all": "yarn workspaces foreach -pvt run test",
+		"start:all": "yarn workspaces foreach -piv run start",
+		"deploy:all": "yarn workspaces foreach -piv run deploy",
+		"test:unit": "jest --ci --coverage",
 		"lint": "essex lint --docs",
 		"lint:fix": "essex lint --fix",
 		"git_is_clean": "essex git-is-clean",
 		"prettify": "essex prettify",
-		"git-is-clean": "essex git-is-clean",
-		"ci": "run-s build_all lint test_all unit_test git_is_clean"
+		"ci": "run-s build_all lint test:all test:unit git_is_clean"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"preinstall": "npx only-allow yarn",
 		"clean:all": "yarn workspaces foreach -pv run clean",
-		"build:": "yarn workspaces foreach -pvt run build",
+		"build:all": "yarn workspaces foreach -pvt run build",
 		"test:all": "yarn workspaces foreach -pvt run test",
 		"start:all": "yarn workspaces foreach -piv run start",
 		"deploy:all": "yarn workspaces foreach -piv run deploy",
@@ -13,7 +13,7 @@
 		"lint:fix": "essex lint --fix",
 		"git_is_clean": "essex git-is-clean",
 		"prettify": "essex prettify",
-		"ci": "run-s build_all lint test:all test:unit git_is_clean"
+		"ci": "run-s build:all lint test:all test:unit git_is_clean"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.12.10",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -31,6 +31,7 @@
 		"typescript": "^4.0.3"
 	},
 	"scripts": {
+		"start:webapp": "yarn start",
 		"start": "react-scripts start",
 		"build": "react-scripts build",
 		"eject": "react-scripts eject"


### PR DESCRIPTION
With yarn 2, any task containing a colon character can be driven from any working directory inside the monorepo. To streamline some dev tasks, this PR changes top-level build orchestration tasks to contain the ":" character, and adds a "start:webapp" task to the webapp so that it can be started independently from the top level