### PR TITLE
Add Pending PRs and Open "scrapped changes" Issues to web app dashboard

### DIFF
--- a/packages/webapp/src/actions/repoActions.ts
+++ b/packages/webapp/src/actions/repoActions.ts
@@ -4,10 +4,6 @@
  */
 import { action } from 'satcheljs'
 
-export const getBranches = action('getBranches')
-
-//export const createPR = action('createPR');
-
 export const createPR = action('createPR', (fileData: any) => ({
 	fileData,
 }))

--- a/packages/webapp/src/components/Dashboard.scss
+++ b/packages/webapp/src/components/Dashboard.scss
@@ -12,5 +12,15 @@
 
 	.sectionContent {
 		padding: 20px 0;
+
+		.tableActionLink{
+			text-decoration:none;
+			color:unset;
+			i {
+				color: #0078d4;
+				vertical-align:middle; 
+				padding-right:5px;
+			}
+		}
 	}
 }

--- a/packages/webapp/src/components/Dashboard.tsx
+++ b/packages/webapp/src/components/Dashboard.tsx
@@ -10,8 +10,8 @@
 	FontIcon
 } from '@fluentui/react'
 import { observer } from 'mobx-react-lite'
-import { getAppStore } from '../store/store'
 import { useState, useEffect } from 'react'
+import { getAppStore } from '../store/store'
 
 
 
@@ -28,8 +28,8 @@ export default observer(function Dashboard() {
 	useEffect(() => { 
 		if(state.issues){
 
-			let tempPRList:any = [];
-			let tempIssueList:any = [];
+			const tempPRList:any = [];
+			const tempIssueList:any = [];
 			state.issues.forEach( (item:any) => {
 
 				const requestUpdate:Date = new Date(item.updated_at);
@@ -55,7 +55,7 @@ export default observer(function Dashboard() {
 
 	const onIssueActionRender =  (item?: any, index?: number, column?: IColumn) =>  {
 
-		return (<a className="tableActionLink" href={item?.action?.html_url} target="_blank" >
+		return (<a className="tableActionLink" href={item?.action?.html_url} target="_blank" rel="noreferrer">
 							<FontIcon
 								iconName="CircleAdditionSolid"
 							/> 
@@ -66,7 +66,7 @@ export default observer(function Dashboard() {
 
 	const onPRActionRender =  (item?: any, index?: number, column?: IColumn) =>  {
 
-		return (<a className="tableActionLink" href={item?.action?.html_url} target="_blank" >
+		return (<a className="tableActionLink" href={item?.action?.html_url} target="_blank" rel="noreferrer">
 							<FontIcon
 								iconName="CircleAdditionSolid"
 							/> 

--- a/packages/webapp/src/components/Dashboard.tsx
+++ b/packages/webapp/src/components/Dashboard.tsx
@@ -2,11 +2,145 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
+ import {
+	DetailsList,
+	DetailsListLayoutMode,
+	ProgressIndicator,
+	IColumn,
+	FontIcon
+} from '@fluentui/react'
 import { observer } from 'mobx-react-lite'
+import { getAppStore } from '../store/store'
+import { useState, useEffect } from 'react'
+
+
 
 import './Dashboard.scss'
 
 export default observer(function Dashboard() {
+
+	const state = getAppStore()
+
+	const [prList, setPRList] = useState<any[]>([])
+	const [issueList, setIssueList] = useState<any[]>([])
+
+
+	useEffect(() => { 
+		if(state.issues){
+
+			let tempPRList:any = [];
+			let tempIssueList:any = [];
+			state.issues.forEach( (item:any) => {
+
+				const requestUpdate:Date = new Date(item.updated_at);
+				const isScrappedIssue = item.labels.some( (x:any) => x.name.toLowerCase() === "scrapped changes" )
+
+				if(item.pull_request){
+
+					tempPRList.push({ title:item.title, author:item.user.login, update:requestUpdate.toLocaleString(), action:item});
+				} 
+				else if (isScrappedIssue){
+					tempIssueList.push({ title:item.title, author:item.user.login, update:requestUpdate.toLocaleString(), action:item});
+				}
+
+			} );
+
+			setPRList(tempPRList);
+			setIssueList(tempIssueList);
+
+		}
+
+
+	},[state.issues])
+
+	const onIssueActionRender =  (item?: any, index?: number, column?: IColumn) =>  {
+
+		return (<a className="tableActionLink" href={item?.action?.html_url} target="_blank" >
+							<FontIcon
+								iconName="CircleAdditionSolid"
+							/> 
+							View</a>)
+
+	};
+
+
+	const onPRActionRender =  (item?: any, index?: number, column?: IColumn) =>  {
+
+		return (<a className="tableActionLink" href={item?.action?.html_url} target="_blank" >
+							<FontIcon
+								iconName="CircleAdditionSolid"
+							/> 
+							Approve</a>)
+
+	};
+
+	const prColumns = [
+		{
+			key: 'titleCol',
+			name: 'Title',
+			fieldName: 'title',
+			minWidth: 200,
+			isResizable: true,
+		},
+		{
+			key: 'authorCol',
+			name: 'Author',
+			fieldName: 'author',
+			minWidth: 200,
+			isResizable: true,
+		},
+		{
+			key: 'updateCol',
+			name: 'Last Update',
+			fieldName: 'update',
+			minWidth: 200,
+			isResizable: true,
+		},
+		{
+			key: 'actionCol',
+			name: '',
+			ariaLabel:'Actions Column',
+			fieldName: 'action',
+			minWidth: 200,
+			isResizable: true,
+			onRender: onPRActionRender
+		},
+	];
+
+	const issueColumns = [
+		{
+			key: 'titleCol',
+			name: 'Title',
+			fieldName: 'title',
+			minWidth: 200,
+			isResizable: true,
+		},
+		{
+			key: 'authorCol',
+			name: 'Author',
+			fieldName: 'author',
+			minWidth: 200,
+			isResizable: true,
+		},
+		{
+			key: 'updateCol',
+			name: 'Last Update',
+			fieldName: 'update',
+			minWidth: 200,
+			isResizable: true,
+		},
+		{
+			key: 'actionCol',
+			name: '',
+			ariaLabel:'Actions Column',
+			fieldName: 'action',
+			minWidth: 200,
+			isResizable: true,
+			onRender: onIssueActionRender
+		},
+
+	];
+
 	return (
 		<div className="dashboardPageWrapper">
 			<div className="bodyContainer">
@@ -17,14 +151,45 @@ export default observer(function Dashboard() {
 					</div>
 				</div>
 				<div className="bodyContent">
-					<section>
+					{ state.issues ? (
+						<section>
 						<div className="sectionHeader">Pending PRs</div>
-						<div className="sectionContent">list of PRs</div>
-					</section>
-					<section>
+						<div className="sectionContent">
+						<DetailsList
+							items={prList}
+							columns={prColumns}
+							setKey="set"
+							layoutMode={DetailsListLayoutMode.justified}
+							ariaLabelForSelectionColumn="Toggle selection"
+							ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+							checkButtonAriaLabel="Row checkbox"
+							checkboxVisibility={2}
+						/>
+						{ !prList.length && (
+							<div style={{textAlign:"center"}}>No pending PRs at this time.</div>
+						) }
+						</div>
 						<div className="sectionHeader">Location Updates</div>
-						<div className="sectionContent">list of updated locations</div>
+						<div className="sectionContent">
+							<DetailsList
+							items={issueList}
+							columns={issueColumns}
+							setKey="set"
+							layoutMode={DetailsListLayoutMode.justified}
+							ariaLabelForSelectionColumn="Toggle selection"
+							ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+							checkButtonAriaLabel="Row checkbox"
+							checkboxVisibility={2}
+						/>
+						{ !issueList.length && (
+							<div style={{textAlign:"center"}}>No pending location updates at this time.</div>
+						) }
+						</div>
+					</section>):(
+					<section>
+						<ProgressIndicator description="Loading content..." />
 					</section>
+					) }
 				</div>
 			</div>
 		</div>

--- a/packages/webapp/src/components/LocationsRegions.tsx
+++ b/packages/webapp/src/components/LocationsRegions.tsx
@@ -3,8 +3,8 @@
  * Licensed under the MIT license. See LICENSE file in the project.
  */
 import { DetailsList, DetailsListLayoutMode } from '@fluentui/react'
-import { useState, useRef, useEffect, useCallback } from 'react'
 import { observer } from 'mobx-react-lite'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { toProperCase } from '../utils/textUtils'
 import LocationsPhases from './LocationsPhases'
 

--- a/packages/webapp/src/mutators/repoMutators.ts
+++ b/packages/webapp/src/mutators/repoMutators.ts
@@ -17,6 +17,16 @@ export const setBranchList = mutatorAction(
 	}
 )
 
+export const setIssuesList = mutatorAction(
+	'setIssuesList',
+	(data: any[] | undefined) => {
+		if (data) {
+			const store = getAppStore()
+			store.issues = data
+		}
+	}
+)
+
 export const handleCreatePR = mutatorAction(
 	'handleCreatePR',
 	(data: any[] | undefined) => {

--- a/packages/webapp/src/orchestrators/repoOrchestrators.ts
+++ b/packages/webapp/src/orchestrators/repoOrchestrators.ts
@@ -4,7 +4,6 @@
  */
 import { orchestrator } from 'satcheljs'
 import {
-	getBranches,
 	createPR,
 	getRepoFileData,
 	initializeGitData,
@@ -13,13 +12,10 @@ import {
 	setBranchList,
 	handleCreatePR,
 	setRepoFileData,
+	setIssuesList
 } from '../mutators/repoMutators'
 import { repoServices } from '../services/repoServices'
 
-orchestrator(getBranches, async () => {
-	const resp = await repoServices('getBranches')
-	setBranchList(resp)
-})
 
 orchestrator(createPR, async (message) => {
 	const { fileData } = message
@@ -38,4 +34,7 @@ orchestrator(initializeGitData, async () => {
 
 	resp = await repoServices('getRepoFileData')
 	setRepoFileData(resp)
+
+	resp = await repoServices('getIssues')
+	setIssuesList(resp)
 })

--- a/packages/webapp/src/services/repoServices.ts
+++ b/packages/webapp/src/services/repoServices.ts
@@ -46,215 +46,238 @@ export const repoServices = async (
 	const githubRepoOwner = process.env.REACT_APP_REPO_OWNER
 	const githubRepoName = process.env.REACT_APP_REPO_NAME
 
-	if (command === 'getBranches') {
-		const response = await fetch(
-			`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/branches`,
-			{
-				method: 'GET',
-				headers: {
-					Authorization: `token ${state.accessToken}`,
-				},
-			}
-		)
-
-		const data = await response.json()
-
-		return data
-	}
-
-	if (command === 'getRepoFileData') {
-		const dataFolderResp = await fetch(
-			`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/contents/packages/plans/data`,
-			{
-				method: 'GET',
-				headers: {
-					Authorization: `token ${state.accessToken}`,
-				},
-			}
-		)
-		const dataFolderObj = await dataFolderResp.json()
-		const policyFolderGitUrl = dataFolderObj.find(
-			(folder: { name: string }) => folder.name === 'policies'
-		).git_url
-		const response = await fetch(`${policyFolderGitUrl}?recursive=true`, {
-			method: 'GET',
-			headers: {
-				Authorization: `token ${state.accessToken}`,
-			},
-		})
-		const data = await response.json()
-		const stateData: any = {}
-		data.tree.forEach(async (element: any) => {
-			if (element.type === 'tree') {
-				createPath(stateData, element.path)
-			} else {
-				const lastInstance = element.path.lastIndexOf('/')
-				const filePath = element.path.substring(0, lastInstance)
-				const fileName: string = element.path.substring(lastInstance + 1)
-				const fileType: string = fileName.split('.')[0]
-				const fileObj: any = {}
-
-				const fileData = await getContent(
-					String(element.url),
-					String(state.accessToken)
-				)
-
-				switch (fileName.split('.')[1].toLowerCase()) {
-					case 'json':
-						fileObj[fileType] = {
-							name: fileName,
-							type: fileType,
-							sha: element.sha,
-							url: element.url,
-							path: element.path,
-							content: JSON.parse(b64_to_utf8(fileData.content)),
-						}
-						break
-					case 'md':
-						fileObj['desc_md'] = {
-							name: fileName,
-							type: fileType,
-							sha: element.sha,
-							url: element.url,
-							path: element.path,
-							content: b64_to_utf8(fileData.content),
-						}
-
-						break
-					case 'csv':
-						fileObj['strings'] = {
-							name: fileName,
-							type: fileType,
-							sha: element.sha,
-							url: element.url,
-							path: element.path,
-							content: convertCSVDataToObj(
-								parse(b64_to_utf8(fileData.content), { columns: true })
-							),
-						}
-
-						break
-				}
-
-				if (fileObj !== {}) {
-					createPath(stateData, filePath, fileObj)
-				}
-			}
-		})
-
-		const localizationFolderGitUrl = dataFolderObj.find(
-			(folder: { name: string }) => folder.name === 'localization'
-		).git_url
-
-		const localizationResponse = await fetch(
-			`${localizationFolderGitUrl}?recursive=true`,
-			{
-				method: 'GET',
-				headers: {
-					Authorization: `token ${state.accessToken}`,
-				},
-			}
-		)
-
-		const localizationData = await localizationResponse.json()
-
-		const customStrings = localizationData.tree.find(
-			(file: { path: string }) => file.path === 'custom-strings.csv'
-		)
-		const cdcStateNames = localizationData.tree.find(
-			(file: { path: string }) => file.path === 'cdc-state-names.csv'
-		)
-		const cdcStateLinks = localizationData.tree.find(
-			(file: { path: string }) => file.path === 'cdc-state-links.csv'
-		)
-
-		let customStringsData: any = {}
-		let cdcStateNamesData: any = {}
-		let cdcStateLinksData: any = {}
-
-		const customStringsDataParse = await getContent(
-			String(customStrings.url),
-			String(state.accessToken)
-		)
-		customStringsData = convertCSVDataToObj(
-			parse(b64_to_utf8(customStringsDataParse.content), { columns: true })
-		)
-
-		const cdcStateNamesDataParse = await getContent(
-			String(cdcStateNames.url),
-			String(state.accessToken)
-		)
-		cdcStateNamesData = convertCSVDataToObj(
-			parse(b64_to_utf8(cdcStateNamesDataParse.content), { columns: true })
-		)
-
-		const cdcStateLinksDataParse = await getContent(
-			String(cdcStateLinks.url),
-			String(state.accessToken)
-		)
-		cdcStateLinksData = convertCSVDataToObj(
-			parse(b64_to_utf8(cdcStateLinksDataParse.content), { columns: true })
-		)
-
-		customStrings['content'] = customStringsData
-		cdcStateNames['content'] = cdcStateNamesData
-		cdcStateLinks['content'] = cdcStateLinksData
-
-		return [stateData, customStrings, cdcStateNames, cdcStateLinks]
-	}
-
-	if (command === 'createPR') {
-		if (state?.mainBranch) {
-			const mainBranch = state?.mainBranch
-			const branchName = `refs/heads/${state.username}-policy-${Date.now()}`
-			const response = await fetch(
-				`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/git/refs`,
+	switch(command){
+		case 'getBranches':
+			const loadBranchesResponse = await fetch(
+				`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/branches`,
 				{
-					method: 'POST',
+					method: 'GET',
 					headers: {
 						Authorization: `token ${state.accessToken}`,
 					},
-					body: JSON.stringify({ ref: branchName, sha: mainBranch.commit.sha }),
 				}
 			)
 
-			const newBranch = await response.json()
-
-			const fileResp = await fetch(
-				`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/contents/packages/plans/data/policies/${extraData.path}`,
-				{
-					method: 'PUT',
-					headers: {
-						Authorization: `token ${state.accessToken}`,
-					},
-					body: JSON.stringify({
-						branch: branchName,
-						message: 'auto file creation',
-						content: utf8_to_b64('[FileContent]'),
-						sha: extraData.sha,
-					}),
-				}
-			)
-
-			const prResp = await fetch(
+			return await loadBranchesResponse.json();
+		case 'getPullRequests':
+			const loadPRResponse = await fetch(
 				`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/pulls`,
 				{
-					method: 'POST',
+					method: 'GET',
 					headers: {
 						Authorization: `token ${state.accessToken}`,
 					},
-					body: JSON.stringify({
-						head: branchName,
-						base: 'main',
-						title: 'auto PR creation',
-					}),
 				}
 			)
 
-			console.log(newBranch, fileResp)
+			return await loadPRResponse.json();
+		case 'getIssues':
+			const loadIssuesResponse = await fetch(
+				`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/issues`,
+				{
+					method: 'GET',
+					headers: {
+						Authorization: `token ${state.accessToken}`,
+					},
+				}
+			)
 
-			return prResp.json()
-		}
+			return await loadIssuesResponse.json();
+		break
+		break;
+		case 'getRepoFileData':
+			const dataFolderResp = await fetch(
+				`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/contents/packages/plans/data`,
+				{
+					method: 'GET',
+					headers: {
+						Authorization: `token ${state.accessToken}`,
+					},
+				}
+			)
+			const dataFolderObj = await dataFolderResp.json()
+			const policyFolderGitUrl = dataFolderObj.find(
+				(folder: { name: string }) => folder.name === 'policies'
+			).git_url
+			const loadPolicyFolderResponse = await fetch(`${policyFolderGitUrl}?recursive=true`, {
+				method: 'GET',
+				headers: {
+					Authorization: `token ${state.accessToken}`,
+				},
+			})
+			const policyFolderData = await loadPolicyFolderResponse.json()
+			const stateData: any = {}
+			policyFolderData.tree.forEach(async (element: any) => {
+				if (element.type === 'tree') {
+					createPath(stateData, element.path)
+				} else {
+					const lastInstance = element.path.lastIndexOf('/')
+					const filePath = element.path.substring(0, lastInstance)
+					const fileName: string = element.path.substring(lastInstance + 1)
+					const fileType: string = fileName.split('.')[0]
+					const fileObj: any = {}
+
+					const fileData = await getContent(
+						String(element.url),
+						String(state.accessToken)
+					)
+
+					switch (fileName.split('.')[1].toLowerCase()) {
+						case 'json':
+							fileObj[fileType] = {
+								name: fileName,
+								type: fileType,
+								sha: element.sha,
+								url: element.url,
+								path: element.path,
+								content: JSON.parse(b64_to_utf8(fileData.content)),
+							}
+							break
+						case 'md':
+							fileObj['desc_md'] = {
+								name: fileName,
+								type: fileType,
+								sha: element.sha,
+								url: element.url,
+								path: element.path,
+								content: b64_to_utf8(fileData.content),
+							}
+
+							break
+						case 'csv':
+							fileObj['strings'] = {
+								name: fileName,
+								type: fileType,
+								sha: element.sha,
+								url: element.url,
+								path: element.path,
+								content: convertCSVDataToObj(
+									parse(b64_to_utf8(fileData.content), { columns: true })
+								),
+							}
+
+							break
+					}
+
+					if (fileObj !== {}) {
+						createPath(stateData, filePath, fileObj)
+					}
+				}
+			})
+
+			const localizationFolderGitUrl = dataFolderObj.find(
+				(folder: { name: string }) => folder.name === 'localization'
+			).git_url
+
+			const localizationResponse = await fetch(
+				`${localizationFolderGitUrl}?recursive=true`,
+				{
+					method: 'GET',
+					headers: {
+						Authorization: `token ${state.accessToken}`,
+					},
+				}
+			)
+
+			const localizationData = await localizationResponse.json()
+
+			const customStrings = localizationData.tree.find(
+				(file: { path: string }) => file.path === 'custom-strings.csv'
+			)
+			const cdcStateNames = localizationData.tree.find(
+				(file: { path: string }) => file.path === 'cdc-state-names.csv'
+			)
+			const cdcStateLinks = localizationData.tree.find(
+				(file: { path: string }) => file.path === 'cdc-state-links.csv'
+			)
+
+			let customStringsData: any = {}
+			let cdcStateNamesData: any = {}
+			let cdcStateLinksData: any = {}
+
+			const customStringsDataParse = await getContent(
+				String(customStrings.url),
+				String(state.accessToken)
+			)
+			customStringsData = convertCSVDataToObj(
+				parse(b64_to_utf8(customStringsDataParse.content), { columns: true })
+			)
+
+			const cdcStateNamesDataParse = await getContent(
+				String(cdcStateNames.url),
+				String(state.accessToken)
+			)
+			cdcStateNamesData = convertCSVDataToObj(
+				parse(b64_to_utf8(cdcStateNamesDataParse.content), { columns: true })
+			)
+
+			const cdcStateLinksDataParse = await getContent(
+				String(cdcStateLinks.url),
+				String(state.accessToken)
+			)
+			cdcStateLinksData = convertCSVDataToObj(
+				parse(b64_to_utf8(cdcStateLinksDataParse.content), { columns: true })
+			)
+
+			customStrings['content'] = customStringsData
+			cdcStateNames['content'] = cdcStateNamesData
+			cdcStateLinks['content'] = cdcStateLinksData
+
+			return [stateData, customStrings, cdcStateNames, cdcStateLinks]
+		break;
+		case 'createPR':
+			if (state?.mainBranch) {
+				const mainBranch = state?.mainBranch
+				const branchName = `refs/heads/${state.username}-policy-${Date.now()}`
+				const createBranchResponse = await fetch(
+					`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/git/refs`,
+					{
+						method: 'POST',
+						headers: {
+							Authorization: `token ${state.accessToken}`,
+						},
+						body: JSON.stringify({ ref: branchName, sha: mainBranch.commit.sha }),
+					}
+				)
+
+				const newBranch = await createBranchResponse.json()
+
+				const fileResp = await fetch(
+					`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/contents/packages/plans/data/policies/${extraData.path}`,
+					{
+						method: 'PUT',
+						headers: {
+							Authorization: `token ${state.accessToken}`,
+						},
+						body: JSON.stringify({
+							branch: branchName,
+							message: 'auto file creation',
+							content: utf8_to_b64('[FileContent]'),
+							sha: extraData.sha,
+						}),
+					}
+				)
+
+				const prResp = await fetch(
+					`https://api.github.com/repos/${githubRepoOwner}/${githubRepoName}/pulls`,
+					{
+						method: 'POST',
+						headers: {
+							Authorization: `token ${state.accessToken}`,
+						},
+						body: JSON.stringify({
+							head: branchName,
+							base: 'main',
+							title: 'auto PR creation',
+						}),
+					}
+				)
+
+				console.log(newBranch, fileResp)
+
+				return prResp.json()
+			}
+		break;
 	}
 
 	return undefined

--- a/packages/webapp/src/store/schema/AppState.ts
+++ b/packages/webapp/src/store/schema/AppState.ts
@@ -9,6 +9,7 @@ export interface AppState {
 	email?: string
 	userDisplayName?: string
 	branches?: any[]
+	issues?: any[]
 	mainBranch?: any
 	repoFileData?: any[]
 	globalFileData?: any

--- a/packages/webapp/src/store/store.ts
+++ b/packages/webapp/src/store/store.ts
@@ -13,6 +13,7 @@ export const getAppState = (): AppState => {
 		email: undefined,
 		userDisplayName: undefined,
 		branches: undefined,
+		issues: undefined,
 		repoFileData: undefined,
 		globalFileData: undefined,
 		mainBranch: undefined,


### PR DESCRIPTION
Uses the fact that github's API endpoint for `/issues` returns both issues and prs but keeping the old code there explicitly for the time being incase we need to revert.