### PR TITLE
Alabama age update

### DIFF
--- a/packages/plans/data/policies/alabama/vaccination.json
+++ b/packages/plans/data/policies/alabama/vaccination.json
@@ -110,7 +110,7 @@
 					"moreInfoText": "c19.eligibility.moreinfo/essential_worker.al.1c_group1"
 				},
 				{
-					"question": "c19.eligibility.question/age.65_up"
+					"question": "c19.eligibility.question/age.55_up"
 				},
 				{
 					"question": "c19.eligibility.question/congregate.do",


### PR DESCRIPTION
1) Adjusted age eligibility from 65+ to 55+

Source: https://www.alabamapublichealth.gov/covid19vaccine/distribution.html