### PR TITLE
Florida updates

### DIFF
--- a/packages/plans/data/policies/florida/vaccination.json
+++ b/packages/plans/data/policies/florida/vaccination.json
@@ -22,13 +22,7 @@
 					"moreInfoText": "c19.eligibility.moreinfo/health.1a.fl.extremely_vulnerable.fl.1a"
 				},
 				{
-					"question": "c19.eligibility.question/age.60_up"
-				},
-				{
-					"question": "c19.eligibility.question/essential_worker.are_you_a"
-				},
-				{
-					"question": "c19.eligibility.question/essential_worker.are_you_a_k"
+					"question": "c19.eligibility.question/age.are"
 				}
 			],
 			"label": "Current phase"


### PR DESCRIPTION
1) Adjusted age qualifier to 50+
2) Removed qualifiers that were essential worker position + age 50+ (since duplicative with overall age requirement)