### PR TITLE
Arizona 3/29 county updates

### DIFF
--- a/packages/plans/data/policies/arizona/regions/apache/vaccination.json
+++ b/packages/plans/data/policies/arizona/regions/apache/vaccination.json
@@ -1,5 +1,5 @@
 {
-	"activePhase": "1c",
+	"activePhase": "18_and_older",
 	"links": {
 		"info": {
 			"text": "c19.links/info.az.apachenavajo",

--- a/packages/plans/data/policies/arizona/regions/maricopa/vaccination.json
+++ b/packages/plans/data/policies/arizona/regions/maricopa/vaccination.json
@@ -8,5 +8,5 @@
 			]
 		}
 	},
-	"activePhase": "1c"
+	"activePhase": "1b_16_and_older"
 }

--- a/packages/plans/data/policies/arizona/regions/mojave/vaccination.json
+++ b/packages/plans/data/policies/arizona/regions/mojave/vaccination.json
@@ -9,5 +9,5 @@
 			"url": "https://www.mohavecounty.us/ContentPage.aspx?id=127&cid=1444&page=2&rid=2230"
 		}
 	},
-	"activePhase": "1c"
+	"activePhase": "1b_16_and_older"
 }

--- a/packages/plans/data/policies/arizona/regions/pima/vaccination.json
+++ b/packages/plans/data/policies/arizona/regions/pima/vaccination.json
@@ -1,5 +1,5 @@
 {
-	"activePhase": "1c",
+	"activePhase": "1b_16_and_older",
 	"links": {
 		"info": {
 			"text": "c19.links/info.az.pima",

--- a/packages/plans/data/policies/arizona/regions/santa_cruz/vaccination.json
+++ b/packages/plans/data/policies/arizona/regions/santa_cruz/vaccination.json
@@ -1,5 +1,5 @@
 {
-	"activePhase": "1b",
+	"activePhase": "1c",
 	"links": {
 		"info": {
 			"text": "c19.links/info.az.santacruz",


### PR DESCRIPTION
Updated county active phases:
Santa Cruz - 55+
Apache - 18+
Maricopa, Mohave, Pima - 16+
