### PR TITLE
Vermont 3/29 updates

### DIFF
--- a/packages/plans/data/policies/vermont/vaccination.json
+++ b/packages/plans/data/policies/vermont/vaccination.json
@@ -21,7 +21,7 @@
 			"text": "c19.link/scheduling.phone.vt"
 		}
 	},
-	"activePhase": "1a",
+	"activePhase": "1c",
 	"phases": [
 		{
 			"id": "1a",
@@ -90,7 +90,7 @@
 					"moreInfoUrl": "https://www.healthvermont.gov/covid-19/vaccine/getting-covid-19-vaccine#conditions"
 				},
 				{
-					"question": "c19.eligibility.question/age.60_up"
+					"question": "c19.eligibility.question/age.are"
 				},
 				{
 					"question": "c19.eligibility.question/essential_worker.are",
@@ -106,7 +106,8 @@
 					"moreInfoText": "c19.eligibility.moreinfo/people_of_color.do.vt.1c",
 					"moreInfoUrl": "https://www.healthvermont.gov/covid-19/vaccine/about-covid-19-vaccines-vermont#equity"
 				}
-			]
+			],
+			"label": "Current"
 		}
 	]
 }


### PR DESCRIPTION
Updated active phase to 1C (meant to do that before, apparently it didn't stick- note to Dr. Karipineni, please confirm if this phase has adequate language around BIPOC folks and English language learners per previous review comments)
Updated age to 50+
Changed phase 1C name to “Current”
