### PR TITLE
Nebraska updates 4/5

### DIFF
--- a/packages/plans/data/policies/nebraska/nebraska.csv
+++ b/packages/plans/data/policies/nebraska/nebraska.csv
@@ -1,5 +1,5 @@
 String ID,en-us,ko-kr,vi-vn,zh-cn,es-us,de-de,es-es,fi-fi,fr-fr,he-il,it-it,ja-jp,pt-pt,sv-se,th-th
-c19.link/scheduling.phone.ne,833-998-2275,,,,833-998-2275,,,,,,,,,,
+c19.link/scheduling.phone.ne,"833-998-2275",,,,"833-998-2275",,,,,,,,,,
 c19.eligibility.moreinfo/essential_worker.ne.1b,"This includes those working in/as:
 First responders, utilities, homeless shelter staff, corrections staff, educators, Funeral homes, grocery,
 food processing, transportation, US Postal Service, public transit",,,,"Esto incluye a aquellos que trabajan en/como:

--- a/packages/plans/data/policies/nebraska/regions/lancaster/info.json
+++ b/packages/plans/data/policies/nebraska/regions/lancaster/info.json
@@ -1,0 +1,9 @@
+{
+	"id": "lancaster",
+	"metadata": {
+		"code_alpha": "lancaster",
+		"code_numeric": 0
+	},
+	"name": "Lancaster",
+	"type": "county"
+}

--- a/packages/plans/data/policies/nebraska/regions/lancaster/vaccination.json
+++ b/packages/plans/data/policies/nebraska/regions/lancaster/vaccination.json
@@ -1,0 +1,10 @@
+{
+	"activePhase": "2a",
+	"links": {
+		"info": {
+			"url": "https://app.lincoln.ne.gov/city/covid19/",
+			"text": "cdc/nebraska/state_link"
+		}
+	},
+	"noPhaseLabel": false
+}

--- a/packages/plans/data/policies/nebraska/vaccination.json
+++ b/packages/plans/data/policies/nebraska/vaccination.json
@@ -3,7 +3,9 @@
 		"info": {
 			"text": "cdc/nebraska/state_link",
 			"url": "http://dhhs.ne.gov/Pages/COVID-19-Vaccine-Information.aspx",
-			"scrapeQuery": [".dhhs-page-content.dhhs-clearfix"]
+			"scrapeQuery": [
+				".dhhs-page-content.dhhs-clearfix"
+			]
 		},
 		"workflow": {
 			"url": "https://vaccinate.ne.gov/"
@@ -23,7 +25,7 @@
 			"url": "https://dhhs.ne.gov/Documents/COVID-19-Vaccine-Phase-1B-Prioritization.pdf"
 		}
 	},
-	"activePhase": "1b",
+	"activePhase": "2b",
 	"phases": [
 		{
 			"id": "1a",
@@ -74,6 +76,36 @@
 				},
 				{
 					"question": "c19.eligibility.question/age.65_up"
+				}
+			]
+		},
+		{
+			"id": "2a",
+			"label": "2a",
+			"qualifications": [
+				{
+					"question": "c19.eligibility.question/healthcare_worker"
+				},
+				{
+					"question": "c19.eligibility.question/long_term_care_resident"
+				},
+				{
+					"question": "c19.eligibility.question/essential_worker"
+				},
+				{
+					"question": "c19.eligibility.question/health"
+				},
+				{
+					"question": "c19.eligibility.question/age.are"
+				}
+			]
+		},
+		{
+			"id": "2b",
+			"label": "2B",
+			"qualifications": [
+				{
+					"question": "c19.eligibility.question/age.16_up"
 				}
 			]
 		}


### PR DESCRIPTION
Added phases 2a and 2b
Set active phase to 2b for state
Added sublocation for Lancaster County (Lincoln-Lancaster) and set to 2a per https://app.lincoln.ne.gov/city/covid19/vaccine.htm and https://norfolkdailynews.com/state/nebraska/lancaster-county-only-place-where-covid-19-vaccine-eligibility-limited-to-older-people/article_c5fc99cd-4145-5f4e-b96c-bec02882507e.html