### PR TITLE
Update Wyoming active phases per county

### DIFF
--- a/packages/plans/data/policies/wyoming/regions/albany/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/albany/vaccination.json
@@ -13,5 +13,6 @@
 			"text": "c19.link/scheduling.phone.albany",
 			"description": "c19.link/scheduling.phone.description.albany"
 		}
-	}
+	},
+	"activePhase": "16_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/bighorn/info.json
+++ b/packages/plans/data/policies/wyoming/regions/bighorn/info.json
@@ -2,7 +2,7 @@
 	"id": "bighorn",
 	"metadata": {
 		"code_alpha": "bighorn",
-		"code_numeric": 0 
+		"code_numeric": 0
 	},
 	"name": "Big Horn",
 	"type": "county"

--- a/packages/plans/data/policies/wyoming/regions/bighorn/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/bighorn/vaccination.json
@@ -13,6 +13,6 @@
 			"text": "c19.link/scheduling.phone.bighorn"
 		}
 	},
-	"activePhase": "16_and_older",
+	"activePhase": "18_and_older",
 	"noPhaseLabel": false
 }

--- a/packages/plans/data/policies/wyoming/regions/campbell/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/campbell/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.campbell"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/carbon/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/carbon/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.carbon"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/converse/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/converse/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.converse"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/crook/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/crook/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.wy.crook"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/fremont/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/fremont/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.fremont"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/goshen/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/goshen/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.goshen"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/hot_springs/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/hot_springs/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.hot_springs"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/johnson/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/johnson/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.johnson"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/laramie/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/laramie/vaccination.json
@@ -12,5 +12,6 @@
 			"url": "tel:307-633-4000",
 			"text": "c19.link/scheduling.phone.laramie"
 		}
-	}
+	},
+	"activePhase": "16_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/niobrara/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/niobrara/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.niobrara"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/park/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/park/vaccination.json
@@ -12,5 +12,6 @@
 			"url": "tel:1-800-438-5795",
 			"text": "c19.link/scheduling.phone.park"
 		}
-	}
+	},
+	"activePhase": "16_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/sublette/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/sublette/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.sublette"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/sweetwater/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/sweetwater/vaccination.json
@@ -9,7 +9,7 @@
 			"text": "c19.link/scheduling.phone.sweetwater"
 		}
 	},
-	"activePhase": "16_and_older",
+	"activePhase": "18_and_older",
 	"phases": [
 		{
 			"id": "1a",

--- a/packages/plans/data/policies/wyoming/regions/teton/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/teton/vaccination.json
@@ -12,5 +12,6 @@
 			"url": "tel:307-732-8628",
 			"text": "c19.link/scheduling.phone.teton"
 		}
-	}
+	},
+	"activePhase": "16_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/uinta/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/uinta/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.uinta"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/washakie/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/washakie/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.washakie"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/regions/weston/vaccination.json
+++ b/packages/plans/data/policies/wyoming/regions/weston/vaccination.json
@@ -13,5 +13,5 @@
 			"text": "c19.link/scheduling.phone.weston"
 		}
 	},
-	"activePhase": "16_and_older"
+	"activePhase": "18_and_older"
 }

--- a/packages/plans/data/policies/wyoming/vaccination.json
+++ b/packages/plans/data/policies/wyoming/vaccination.json
@@ -16,7 +16,7 @@
 			"description": "c19.link/scheduling.phone.description.wy"
 		}
 	},
-	"activePhase": "16_and_older",
+	"activePhase": "18_and_older",
 	"phases": [
 		{
 			"id": "1a",


### PR DESCRIPTION
Set overall state to 18+
Set sublocations:
Albany – 16+
Big Horn – 18+
Campbell – 18+
Carbon – 18+
Converse – 18+
Crook – 18+
Fremont – 18+
Goshen – 18+
Hot Springs – 18+
Johnson – 18+
Laramie – 16+
Lincoln – 18+
Natrona – 16+
Niobrara – 18+
Park – 16+
Platte – 18+
Sheridan- 16+
Sublette – 18+
Sweetwater – 18+
Teton – 16+
Uinta – 18+
Washakie- 18+ 
Weston- 18+