### PR TITLE
fix: add last_updated field to location documents

### DIFF
--- a/packages/locations-ingester/package.json
+++ b/packages/locations-ingester/package.json
@@ -8,11 +8,14 @@
 	"scripts": {
 		"clean": "essex clean lib .cache node_modules deploy.zip package-lock.json",
 		"build": "tsc -b .",
+		"ingest:restorecache": "ts-node src/restoreCache",
+		"ingest:persistcache": "ts-node src/persistCache",
 		"ingest:fetch": "ts-node src/fetchS3Data",
 		"ingest:xform": "ts-node src/transformData",
-		"ingest:geocode": "ts-node src/geocodeData",
+		"ingest:geocode": "BUST_GEO_CACHE=1 ts-node src/geocodeData",
+		"ingest:geocode:busted": "BUST_GEO_CACHE=1 yarn ingest:geocode",
 		"ingest:write": "ts-node src/writeCosmosData",
-		"start:ingest": "run-s ingest:fetch ingest:xform ingest:geocode ingest:write",
+		"start:ingest": "run-s ingest:restorecache ingest:fetch ingest:xform ingest:geocode ingest:write",
 		"prearchive": "npm install --production",
 		"archive": "yarn essex zip deploy.zip config lib node_modules VaccineFinderIngest host.json package.json",
 		"deploy": "az functionapp deployment source config-zip --subscription Resilience --resource-group covid-services --name vaxbot-fns --src deploy.zip"

--- a/packages/locations-ingester/src/geocodeData/geocodeCache.ts
+++ b/packages/locations-ingester/src/geocodeData/geocodeCache.ts
@@ -14,7 +14,10 @@ export type GeoCache = Map<string, GeoPoint | null>
 
 export function readGeocodeCache(): GeoCache {
 	const cache = new Map<string, GeoPoint>()
-	if (fs.existsSync(GEO_CACHE_FILE)) {
+	if (process.env.BUST_GEO_CACHE) {
+		console.log('Busting Geo-Cache')
+	} else if (fs.existsSync(GEO_CACHE_FILE)) {
+		console.log('Loading Geo-Cache')
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
 		const data = require(GEO_CACHE_FILE) as PersistedGeoCacheItem[]
 		data.forEach((d) => cache.set(d.id, d.coordinates))

--- a/packages/locations-ingester/src/geocodeData/geocodeData.ts
+++ b/packages/locations-ingester/src/geocodeData/geocodeData.ts
@@ -18,6 +18,7 @@ function getSourceFile(): string {
 	const filePath = getLatestFilePath()
 	return filePath.replace('.csv', '.json')
 }
+
 /**
  * Collates records in the given CSV into the target JSON output format
  * @param file The CSV File path
@@ -112,15 +113,14 @@ async function getPosition(
 async function getPositionFromService(
 	provider: ProviderLocation
 ): Promise<GeoPoint | null> {
-	const query = `${provider.location.street1} ${provider.location.zip}`
 	const response = await axios.get(API_URL, {
 		params: {
 			'api-version': '1.0',
 			'subscription-key': MAPS_KEY,
 			limit: 1,
-			query: `"${query}"`,
+			query: `"${getLocationQueryText(provider)}"`,
 		},
-		timeout: 5000,
+		timeout: 15000,
 	})
 	if (
 		Object.keys(response.headers).some((s) => s.startsWith('x-ms-ratelimit'))
@@ -133,4 +133,11 @@ async function getPositionFromService(
 		null
 	)
 	return pos ? ([pos.lon, pos.lat] as GeoPoint) : null
+}
+
+function getLocationQueryText({
+	location: { street1, city, state, zip },
+}: ProviderLocation): string {
+	return `${street1} 
+	${city}, ${state} ${zip}`
 }

--- a/packages/locations-ingester/src/persistCache/index.ts
+++ b/packages/locations-ingester/src/persistCache/index.ts
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { persistCache } from '../cache'
+
+console.log('persisting cache')
+persistCache().then(() => console.log('cache persisted'))

--- a/packages/locations-ingester/src/restoreCache/index.ts
+++ b/packages/locations-ingester/src/restoreCache/index.ts
@@ -1,0 +1,8 @@
+/*!
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project.
+ */
+import { restoreCache } from '../cache'
+
+console.log('restoring cache')
+restoreCache().then(() => console.log('cache restored'))

--- a/packages/locations-ingester/src/writeCosmosData/writeCosmosData.ts
+++ b/packages/locations-ingester/src/writeCosmosData/writeCosmosData.ts
@@ -52,7 +52,11 @@ async function processLocation(
 	})
 	const result = await queryResponse.fetchAll()
 	const existing = result.resources.length > 0 ? result.resources[0] : {}
-	const updated = { ...existing, ...loc }
+	const updated = {
+		...existing,
+		...loc,
+		last_updated: new Date().toISOString(),
+	}
 	try {
 		await container.items.upsert(updated)
 	} catch (err) {


### PR DESCRIPTION
This allows the API to filter out locations that have not been updated recently, which solves the problem of the services exposing stale data.

In addition, this updates the address search query we use to geocode locations